### PR TITLE
Fix source package build, update pkgdown to use BS 5, and minor typo fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .DS_Store
 .quarto
 inst/doc
+README.html

--- a/README.Rmd
+++ b/README.Rmd
@@ -42,7 +42,7 @@ install.packages("furrr")
 install.packages("fst")
 ```
 
-**Important**: on mac it can be more challenging to enable OpenMP parallel processing as the *clang* compiler does not include an OpenMP runtime as standard. I recommend following the instructions on the `data.table` GitHub [link](https://github.com/Rdatatable/data.table/wiki/Installation). Key for successful installation on my Macbook M2 Max was creating a Makevars file in the root directory `~.R/Makevars`, which is a simple text file, containing the compilation flags below, and then re-installing from source. 
+**Important**: on mac it can be more challenging to enable OpenMP parallel processing as the *clang* compiler does not include an OpenMP runtime as standard. I recommend following the instructions on the `data.table` GitHub [link](https://github.com/Rdatatable/data.table/wiki/Installation). Key for successful installation on my Macbook M2 Max was creating a Makevars file in the root directory `~/.R/Makevars`, which is a simple text file, containing the compilation flags below, and then re-installing from source. 
 
 ```{bash, eval=FALSE}
 LDFLAGS += -L/opt/homebrew/opt/libomp/lib -lomp

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@ genepi.utils
 ================
 
 <!-- README.md is generated from README.Rmd. Please edit that file -->
+
 <!-- badges: start -->
+
 <!-- badges: end -->
 
 The `genepi.utils` package is a collection of utility functions for
@@ -36,7 +38,7 @@ runtime as standard. I recommend following the instructions on the
 `data.table` GitHub
 [link](https://github.com/Rdatatable/data.table/wiki/Installation). Key
 for successful installation on my Macbook M2 Max was creating a Makevars
-file in the root directory `~.R/Makevars`, which is a simple text file,
+file in the root directory `~/.R/Makevars`, which is a simple text file,
 containing the compilation flags below, and then re-installing from
 source.
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,8 @@
 url: https://nicksunderland.github.io/genepi.utils/
+template:
+  bootstrap: 5
+  light-switch: true
+
 reference:
 - title: "GWAS standardisation"
   desc: >

--- a/vignettes/rationale.Rmd
+++ b/vignettes/rationale.Rmd
@@ -380,7 +380,7 @@ GWAS <- new_class(
 ```
 
 ## Load a GWAS
-```{r load_gwas}
+```{r load_gwas, eval = FALSE}
 library(genepi.utils)
 
 # the datafile 


### PR DESCRIPTION
Hi Nick

A few minor things:

* This fixes the source package build failure on <https://mrcieu.r-universe.dev/> - simply it can't run one chunk in the rationale.Rmd vignette - so I just set the offending chunk to not evaluate.

* I have bumped pkgdown to use Bootstrap 5 - so you'll get search and dark mode toggle in top right navbar - you need to update your local version of pkgdown to latest (2.1.1) for this to work ok (you currently have 2.1.0).

  Note you are obvs building your vignettes with different settings , i.e., the currently commented out `knitr::include_graphics()` lines - maybe uncomment those - as currently we'll get no plots on r-universe vignettes (admittedly not really important).

* Also super minor typo fixed in README.